### PR TITLE
Add gulp script to auto install new theme on changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ typings/
 # Gulp #
 release/
 css/
+dist/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,18 +60,26 @@ const dev = () => {
   }
 
   // Watch styles
-  watch(["*.scss", "ursine/*.scss"], { ignoreInitial: false }, () => {
-    return themeLocation
-      ? buildStyles().pipe(dest(themeLocation))
-      : buildStyles();
-  });
+  watch(
+    ["*.scss", "ursine/*.scss"],
+    { ignoreInitial: false },
+    function styleWatcher() {
+      return themeLocation
+        ? buildStyles().pipe(dest(themeLocation))
+        : buildStyles();
+    }
+  );
 
   // Watch assets
-  watch(["ursine/*.(woff|png)"], { ignoreInitial: false }, () => {
-    return themeLocation
-      ? includeAssets().pipe(dest(path.join(themeLocation, "ursine")))
-      : includeAssets();
-  });
+  watch(
+    ["ursine/*.(woff|png)"],
+    { ignoreInitial: false },
+    function assetWatcher() {
+      return themeLocation
+        ? includeAssets().pipe(dest(path.join(themeLocation, "ursine")))
+        : includeAssets();
+    }
+  );
 };
 
 exports.default = parallel(buildStyles, includeAssets);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,47 +1,79 @@
-const { src, dest, series, done } = require('gulp');
-const sass = require('gulp-sass');
-const rename = require('gulp-rename');
-const zip = require('gulp-zip');
-const merge = require('merge-stream');
+const { src, dest, series, parallel, watch } = require("gulp");
+const sass = require("gulp-sass");
+const rename = require("gulp-rename");
+const zip = require("gulp-zip");
+const merge = require("merge-stream");
+const os = require("os");
+const path = require("path");
 
-const build = () => {
-  console.log("Compiling CSS files...")
-  sass.compiler = require('node-sass');
+const buildStyles = () => {
+  console.log("Compiling CSS files...");
+  sass.compiler = require("node-sass");
 
-  return src('*.scss')
-    .pipe(sass({ outputStyle: 'expanded' }).on('error', sass.logError))
-    .pipe(dest('css/'));
-}
+  const regular = src(["*.scss", "!*-cyrillic.scss"])
+    .pipe(sass({ outputStyle: "expanded" }).on("error", sass.logError))
+    .pipe(dest("dist/ursine"));
 
-const makeZip = (cyrillic) => {
-  var cssGlob, assetGlob, zipName;
-  if (cyrillic) {
-    cssGlob = 'css/*-cyrillic.css';
-    assetGlob = ['ursine/*.png', 'ursine/Cousine-Regular.woff', 'ursine/AdelleCyrillic-*.woff', 'ursine/AvenirNextCyr-*.woff']
-    zipName = 'Ursine_Cyrillic.zip';
-  } else {
-    cssGlob = ['css/*.css', '!css/*-cyrillic.css'];
-    assetGlob = ['ursine/*.png', 'ursine/Cousine-Regular.woff', 'ursine/Adelle-*.woff', 'ursine/AvenirNextLTPro-*.woff'];
-    zipName = 'Ursine.zip';
+  const cyrillic = src("*-cyrillic.scss")
+    .pipe(sass({ outputStyle: "expanded" }).on("error", sass.logError))
+    .pipe(dest("dist/ursine-cyrillic"));
+
+  return merge(regular, cyrillic);
+};
+
+const includeAssets = () => {
+  const regular = src([
+    "ursine/*.png",
+    "ursine/Cousine-Regular.woff",
+    "ursine/Adelle-*.woff",
+    "ursine/AvenirNextLTPro-*.woff"
+  ]).pipe(dest("dist/ursine/ursine"));
+
+  const cyrillic = src([
+    "ursine/*.png",
+    "ursine/Cousine-Regular.woff",
+    "ursine/AdelleCyrillic-*.woff",
+    "ursine/AvenirNextCyr-*.woff"
+  ]).pipe(dest("dist/ursine-cyrillic/ursine"));
+
+  console.log("Including assets...");
+  return merge(regular, cyrillic);
+};
+
+const makeZip = () => {
+  const regular = src("dist/ursine/**").pipe(zip("Ursine.zip"));
+
+  const cyrillic = src("dist/ursine-cyrillic/**").pipe(
+    zip("Ursine_Cyrillic.zip")
+  );
+
+  console.log(`Building releases...`);
+  return merge(regular, cyrillic).pipe(dest("./release"));
+};
+
+const dev = () => {
+  let themeLocation;
+  switch (os.type()) {
+    case "Windows_NT":
+      themeLocation = `${process.env.APPDATA}\\Typora\\themes`;
+      break;
   }
 
-  console.log(`Building release ${zipName}...`)
-  return merge(
-    src(cssGlob),
-    src(assetGlob)
-      .pipe(rename((file) => {
-        file.dirname = 'ursine/' + file.dirname;
-      }))
-  )
-    .pipe(zip(zipName))
-    .pipe(dest('./release'));
-}
+  // Watch styles
+  watch(["*.scss", "ursine/*.scss"], { ignoreInitial: false }, () => {
+    return themeLocation
+      ? buildStyles().pipe(dest(themeLocation))
+      : buildStyles();
+  });
 
-const release = (done) => {
-  makeZip(false);
-  makeZip(true);
-  done();
-}
+  // Watch assets
+  watch(["ursine/*.(woff|png)"], { ignoreInitial: false }, () => {
+    return themeLocation
+      ? includeAssets().pipe(dest(path.join(themeLocation, "ursine")))
+      : includeAssets();
+  });
+};
 
-exports.default = build;
-exports.release = series(build, release);
+exports.default = parallel(buildStyles, includeAssets);
+exports.release = series(exports.default, makeZip);
+exports.dev = dev;


### PR DESCRIPTION
`gulp dev` provides a watch mode with auto install

Currently the auto install only works on Windows since I don't know where themes are installed on other platforms