### PR TITLE
Fixed header markers alignment

### DIFF
--- a/ursine-umbra.scss
+++ b/ursine-umbra.scss
@@ -336,7 +336,7 @@ td, th {
       float: none;
       padding: 0;
       vertical-align: baseline;
-      line-height: 20px;
+      line-height: 1.6rem;
     }
   }
 


### PR DESCRIPTION
When changing the default font size, the header markers were not aligned with the title.

Before the change:

![with-pixels](https://user-images.githubusercontent.com/203078/68720162-0404f380-0574-11ea-84b8-99c49bc27cd2.png)

After the change:

![Screenshot from 2019-11-12 17-42-40](https://user-images.githubusercontent.com/203078/68720189-1848f080-0574-11ea-9cf1-d0bb70d12e04.png)
