### PR TITLE
Fix version number and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ npm i
 gulp
 ```
 
+In order to run `gulp` command you need to have `gulp-cli` installed globally with `npm install --global gulp-cli`.
+
 The compiled CSS files will be located in the `/dist` directory once complete.
 
 Three is also a `dev` script that will watch the files and assets & update your themes in your themes folder directly as you save your changes. Simply run `gulp dev` to do so (and remember to reselect the theme in Typora afterwards to see the changes).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typora-theme-ursine",
-  "version": "1.9.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typora-theme-ursine",
-  "version": "2.0",
+  "version": "2.0.0",
   "description": "A Typora theme, inspired by Bear",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparently you have to have version number be three numbers divided by dots. Otherwise npm thinks that package.json is not valid and won't install dependencies.