### PR TITLE
Fix version number for npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typora-theme-ursine",
-  "version": "1.9.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typora-theme-ursine",
-  "version": "2.0",
+  "version": "2.0.0",
   "description": "A Typora theme, inspired by Bear",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparently you have to have version number be three numbers divided by
dots. Otherwise npm thinks that package.json is not valid and won't
install dependencies.